### PR TITLE
Update gemma dependency to 3.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,24 +6,23 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    gemma (2.2.0)
-      bundler (~> 1.1.3)
-      highline (~> 1.6.11)
-      minitest (~> 2.12.1)
-      rake (~> 0.9.2)
+    gemma (3.0.0)
+      highline (~> 1.6.15)
+      minitest (~> 4.3.3)
+      rake (~> 10.0.3)
       rdoc (~> 3.12.0)
-      yard (~> 0.8.1)
+      yard (~> 0.8.3)
     highline (1.6.15)
-    json (1.7.5)
-    minitest (2.12.1)
-    rake (0.9.2.2)
-    rdoc (3.12)
+    json (1.7.7)
+    minitest (4.3.3)
+    rake (10.0.3)
+    rdoc (3.12.2)
       json (~> 1.4)
-    yard (0.8.3)
+    yard (0.8.5.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   fast_rake!
-  gemma (~> 2.2.0)
+  gemma (~> 3.0.0)

--- a/fast_rake.gemspec
+++ b/fast_rake.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'fast_rake'
 
   #s.add_runtime_dependency '...', '~> x.y.z'
-  s.add_development_dependency 'gemma', '~> 2.2.0'
+  s.add_development_dependency 'gemma', '~> 3.0.0'
 
   s.files       = Dir.glob('lib/**/*.rb')
 


### PR DESCRIPTION
This fixes a conflict with versions of bundler > 1.1.x.

Hopefully it doesn't break releasing the gem, but it seems to build OK.

Without this, running `bundle install` on devmac-1 gave this error:

```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    gemma (~> 2.2.0) ruby depends on
      bundler (~> 1.1.3) ruby

  Current Bundler version:
    bundler (1.2.2)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
```
