### PR TITLE
Change regex so that missing args are passed as nil instead of an empty string

### DIFF
--- a/lib/fast_rake/fast_runner.rb
+++ b/lib/fast_rake/fast_runner.rb
@@ -91,7 +91,7 @@ class FastRake::FastRunner
     STDERR.reopen(output_path.join('stderr'), 'w')
 
     setup_database(task_name)
-    task_match = task_name.match(/([^\[]*)\[?([^\]]*)\]?/)
+    task_match = task_name.match(/([^\[]*)(?:\[([^\]]*)\])?/)
     task_name = task_match[1]
     task_args = task_match[2]
     Rake::Task[task_name].invoke(task_args)


### PR DESCRIPTION
This avoids the problem we saw with jasmine:phantom passing an empty # of processes.
