### PR TITLE
Let fast handle the new hash syntax for tasks

### DIFF
--- a/lib/fast_rake/fast_runner.rb
+++ b/lib/fast_rake/fast_runner.rb
@@ -9,7 +9,7 @@ class FastRake::FastRunner
   RESET = "\033[0m"
 
   def initialize(tasks, process_count, fail_fast)
-    @tasks = tasks
+    @tasks = get_task_commands(tasks)
     @process_count = process_count
     @fail_fast = fail_fast
     @children = {}
@@ -42,6 +42,10 @@ class FastRake::FastRunner
   end
 
   private
+
+  def get_task_commands(tasks)
+    tasks.map { |task| task.is_a?(Hash) ? task[:cmd] : task.to_s }
+  end
 
   def results_folder
     Rails.root.join('tmp', 'build')


### PR DESCRIPTION
FastJ allows tasks to be specified as either a string with the name of the rake task to execute, or as a hash with :name, :cmd, and :priority keys.
